### PR TITLE
Prevent misspelling of page credentials

### DIFF
--- a/login/partials/secureheader.php
+++ b/login/partials/secureheader.php
@@ -8,6 +8,12 @@ function checkSessionKey($key)
     return $_SESSION[$key];
 }
 
+$allowed_types = array('superadminpage', 'adminpage', 'userpage', 'loginpage', 'page');
+if (!in_array($pagetype, $allowed_types, true)) {
+    throw new Exception("Server Error: Please contact site administrator and relay this error - xER41400 [".$pagetype."]");
+    exit;
+}
+
 if ($ip != getenv("REMOTE_ADDR") || (checkSessionKey("admin") == false && $pagetype == "adminpage") || (checkSessionKey("username") == false && $pagetype == "userpage")) {
 
     $refurl = urlencode("http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]");


### PR DESCRIPTION
When specifying pagetype-variable it is easy to misspell
"adminpage" or "superadminpage", in this case we do not
want anonymous access to the page. Instead raise an
exception so we won't miss it!